### PR TITLE
Update RecursiveCraft.cs

### DIFF
--- a/RecursiveCraft.cs
+++ b/RecursiveCraft.cs
@@ -63,7 +63,7 @@ namespace RecursiveCraft
 
 			Hotkeys = null;
 
-			if (CompoundRecipe.OverridenRecipe != null)
+			if (CompoundRecipe?.OverridenRecipe != null)
 				Main.recipe[CompoundRecipe.RecipeId] = CompoundRecipe.OverridenRecipe;
 			CompoundRecipe = null;
 


### PR DESCRIPTION
Fixes NullPointerException during Unload after incomplete Load(due to mod loading aborting)